### PR TITLE
[Feature] Paging and filters

### DIFF
--- a/client/src/components/FacilityListing.js
+++ b/client/src/components/FacilityListing.js
@@ -23,7 +23,7 @@ const FacilityListing = ({ data: { loading, error, facilities } }) => {
         <hr/>
         <h3>Pontos de coleta</h3>
         <List>
-          { facilities.map(it =>
+          { facilities.items.map(it =>
             (<div key={it._id} className='facility'>
               <ListItem>
                 <Link to={it._id < 0 ? `/` : `facilities/${it._id}`}>
@@ -40,10 +40,23 @@ const FacilityListing = ({ data: { loading, error, facilities } }) => {
 }
 
 export const facilityListQuery = gql`
-  query FacilityListQuery {
-    facilities {
-      _id
-      name
+  query FacilityListQuery($after: Cursor, $before: Cursor) {
+    facilities(filters: {
+      cursor: {
+        after: $after
+        before: $before
+        quantity: 10
+      }
+    }) {
+      cursors {
+        after
+        before
+      }
+
+      items {
+        _id
+        name
+      }
     }
   }
 `

--- a/server/src/model/facility.js
+++ b/server/src/model/facility.js
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb'
 import { assertNotEmpty } from './validation'
 
 export default ({ Facilities }) => ({
@@ -5,8 +6,49 @@ export default ({ Facilities }) => ({
   async facility (_id) {
     return Facilities.findOne({ _id })
   },
-  async facilities () {
-    return Facilities.find({ enabled: true }).toArray()
+  async facilities ({ cursor, location, hasTypesOfWaste }) {
+    const query = {
+      enabled: true
+    }
+
+    if (cursor.quantity < 0) {
+      cursor.quantity = 1
+    }
+
+    if (cursor.quantity > 100) {
+      cursor.quantity = 100
+    }
+
+    if (cursor.after != null) {
+      query._id = { $gt: ObjectId(cursor.after) }
+    } else if (cursor.before) {
+      query._id = { $lt: ObjectId(cursor.before) }
+    }
+
+    if (hasTypesOfWaste != null && hasTypesOfWaste.length > 0) {
+      query.typesOfWaste = { $in: hasTypesOfWaste }
+    }
+
+    if (location != null && location.near != null) {
+      // TODO: convert lat & long into city using geocoding/local cache
+      // query.city = ...
+    }
+
+    const items =
+      await Facilities
+        .find(query)
+        .limit(cursor.quantity)
+        .toArray()
+
+    const cursors = {
+      before: items.length > 0 ? items[0]._id.toString() : null,
+      after: items.length > 0 ? items[items.length - 1]._id.toString() : null
+    }
+
+    return {
+      cursors,
+      items
+    }
   },
   // Operations
   async addFacility (data) {

--- a/server/src/model/facility.test.js
+++ b/server/src/model/facility.test.js
@@ -24,30 +24,54 @@ describe('Facility querying', () => {
       const context = {
         Facilities: {
           find: () => ({
-            toArray: async () => [1, 2, 3]
+            limit: () => ({
+              toArray: async () => [
+                { _id: "Example 1" },
+                { _id: "Example 2" },
+              ]
+            })
           })
         }
       }
 
-      const model = createModel(context)
-      const result = await model.facilities()
+      const args = {
+        cursor: {
+          quantity: 10
+        }
+      }
 
-      expect(result).toEqual([1, 2, 3])
+      const model = createModel(context)
+      const result = await model.facilities(args)
+
+      expect(result.items).toEqual([{ _id: "Example 1" }, { _id: "Example 2" }])
     })
 
     it('filters out disabled facilities', async () => {
       const context = {
         Facilities: {
           find: (args) => ({
-            toArray: async () => args.enabled === true
+            limit: () => ({
+              toArray: async () => [
+                { 
+                  _id: 'Example 1 ',
+                  passed: args.enabled === true 
+                }
+              ]
+            })
           })
         }
       }
 
-      const model = createModel(context)
-      const result = await model.facilities()
+      const args = {
+        cursor: {
+          quantity: 10
+        }
+      }
 
-      expect(result).toEqual(true)
+      const model = createModel(context)
+      const result = await model.facilities(args)
+
+      expect(result.items).toEqual([{"_id": "Example 1 ", "passed": true}])
     })
   })
 })

--- a/server/src/model/facility.test.js
+++ b/server/src/model/facility.test.js
@@ -26,8 +26,8 @@ describe('Facility querying', () => {
           find: () => ({
             limit: () => ({
               toArray: async () => [
-                { _id: "Example 1" },
-                { _id: "Example 2" },
+                { _id: 'Example 1' },
+                { _id: 'Example 2' }
               ]
             })
           })
@@ -43,7 +43,7 @@ describe('Facility querying', () => {
       const model = createModel(context)
       const result = await model.facilities(args)
 
-      expect(result.items).toEqual([{ _id: "Example 1" }, { _id: "Example 2" }])
+      expect(result.items).toEqual([{ _id: 'Example 1' }, { _id: 'Example 2' }])
     })
 
     it('filters out disabled facilities', async () => {
@@ -52,9 +52,9 @@ describe('Facility querying', () => {
           find: (args) => ({
             limit: () => ({
               toArray: async () => [
-                { 
+                {
                   _id: 'Example 1 ',
-                  passed: args.enabled === true 
+                  passed: args.enabled === true
                 }
               ]
             })
@@ -71,7 +71,7 @@ describe('Facility querying', () => {
       const model = createModel(context)
       const result = await model.facilities(args)
 
-      expect(result.items).toEqual([{"_id": "Example 1 ", "passed": true}])
+      expect(result.items).toEqual([{'_id': 'Example 1 ', 'passed': true}])
     })
   })
 })

--- a/server/src/model/feedback.test.js
+++ b/server/src/model/feedback.test.js
@@ -24,15 +24,26 @@ describe('feedback querying', () => {
       const context = {
         Feedbacks: {
           find: () => ({
-            toArray: async () => [1, 2, 3]
+            limit: () => ({
+              toArray: async () => [
+                { _id: 'Example 1' },
+                { _id: 'Example 2' }
+              ]
+            })
           })
         }
       }
 
-      const model = createModel(context)
-      const result = await model.feedbacks()
+      const args = {
+        cursor: {
+          quantity: 10
+        }
+      }
 
-      expect(result).toEqual([1, 2, 3])
+      const model = createModel(context)
+      const result = await model.feedbacks(args)
+
+      expect(result.items).toEqual([{ _id: 'Example 1' }, { _id: 'Example 2' }])
     })
   })
 })

--- a/server/src/schema/facility/index.js
+++ b/server/src/schema/facility/index.js
@@ -206,37 +206,13 @@ export const schema = `
     near: CoordinatesInput
   }
 
-  # Represents relevant pagination data
-  input FilterCursors {
-    # Indicates that the results must be after a given cursor
-    # Has priority over the 'before' field
-    after: Cursor
-
-    # Indicates that the results must be before a given cursor
-    # The field 'after' has priority over this
-    before: Cursor
-
-    # The total quantity of items that should be retrieved
-    # Must be a value between 1 and 100
-    quantity: Int!
-  }
-
   # Represents the result of the facilities query
   type FacilitiesPage {
     # Cursor information for the next possible requests
-    cursors: PageCursors
+    cursors: PageCursors!
 
     # The items found according to the query
     items: [Facility]
-  }
-
-  # A pair of cursors allowing navigation from this page
-  type PageCursors {
-    # The cursor used to get items from before this page
-    after: Cursor
-
-    # The cursor used to get items from after this page
-    before: Cursor
   }
 `
 export const queryExtension = `

--- a/server/src/schema/facility/index.js
+++ b/server/src/schema/facility/index.js
@@ -187,10 +187,61 @@ export const schema = `
     # Indicates whether the operation was successful
     success: Boolean!
   }
+
+  # Represents the possible filters on facilities
+  input FacilityFilters {
+    # The pagination data
+    cursor: FilterCursors!
+
+    # Requirements related to location
+    location: LocationFilter
+
+    # The types of wast the facility has to support
+    hasTypesOfWaste: [ID]
+  }
+
+  # Filters on location data
+  input LocationFilter {
+    # Indicates roughly where the subject must be located
+    near: CoordinatesInput
+  }
+
+  # Represents relevant pagination data
+  input FilterCursors {
+    # Indicates that the results must be after a given cursor
+    # Has priority over the 'before' field
+    after: Cursor
+
+    # Indicates that the results must be before a given cursor
+    # The field 'after' has priority over this
+    before: Cursor
+
+    # The total quantity of items that should be retrieved
+    # Must be a value between 1 and 100
+    quantity: Int!
+  }
+
+  # Represents the result of the facilities query
+  type FacilitiesPage {
+    # Cursor information for the next possible requests
+    cursors: PageCursors
+
+    # The items found according to the query
+    items: [Facility]
+  }
+
+  # A pair of cursors allowing navigation from this page
+  type PageCursors {
+    # The cursor used to get items from before this page
+    after: Cursor
+
+    # The cursor used to get items from after this page
+    before: Cursor
+  }
 `
 export const queryExtension = `
   # The list of available facilities
-  facilities: [Facility]
+  facilities(filters: FacilityFilters!): FacilitiesPage
 
   # The facility with the given ID
   facility(_id: ID!): Facility

--- a/server/src/schema/facility/queries.js
+++ b/server/src/schema/facility/queries.js
@@ -1,6 +1,6 @@
 export const facilities =
-  (obj, args, { models: { Facilities: { facilities } } }, info) =>
-    facilities()
+  (obj, { filters }, { models: { Facilities: { facilities } } }, info) =>
+    facilities(filters)
 
 export const facility =
   (obj, { _id }, { models: { Facilities: { facility } } }, info) =>

--- a/server/src/schema/feedback/index.js
+++ b/server/src/schema/feedback/index.js
@@ -47,11 +47,28 @@ export const schema = `
     # The resolved entry, if any
     feedback: Feedback
   }
+
+  # Available filters on a feedback query
+  input FeedbackFilters {
+    # The pagination data
+    cursor: FilterCursors!
+
+    # Indicates the required state for the resolved flag
+    resolved: Boolean
+  }
+
+  type FeedbackPage {
+    # Cursor information for the next possible requests
+    cursors: PageCursors!
+
+    # The items found according to the query
+    items: [Feedback]
+  }
 `
 
 export const queryExtension = `
   # Every feedback received
-  feedbacks: [Feedback]
+  feedbacks(filters: FeedbackFilters!): FeedbackPage
 
   # The feedback with the given ID
   feedback(_id: ID!): Feedback

--- a/server/src/schema/feedback/queries.js
+++ b/server/src/schema/feedback/queries.js
@@ -1,6 +1,6 @@
 export const feedbacks =
-  (obj, args, { models: { Feedbacks: { feedbacks } } }, info) =>
-    feedbacks()
+  (obj, { filters }, { models: { Feedbacks: { feedbacks } } }, info) =>
+    feedbacks(filters)
 
 export const feedback =
   (obj, { _id }, { models: { Feedbacks: { feedback } } }, info) =>

--- a/server/src/schema/utilities/index.js
+++ b/server/src/schema/utilities/index.js
@@ -3,6 +3,30 @@ import { Kind } from 'graphql'
 
 export const schema = `
   scalar Cursor
+
+  # Represents relevant pagination data
+  input FilterCursors {
+    # Indicates that the results must be after a given cursor
+    # Has priority over the 'before' field
+    after: Cursor
+
+    # Indicates that the results must be before a given cursor
+    # The field 'after' has priority over this
+    before: Cursor
+
+    # The total quantity of items that should be retrieved
+    # Must be a value between 1 and 100
+    quantity: Int!
+  }
+  
+  # A pair of cursors allowing navigation from this page
+  type PageCursors {
+    # The cursor used to get items from before this page
+    after: Cursor
+
+    # The cursor used to get items from after this page
+    before: Cursor
+  }
 `
 
 export const resolvers = {

--- a/server/src/schema/utilities/index.js
+++ b/server/src/schema/utilities/index.js
@@ -1,6 +1,10 @@
 import { ObjectId } from 'mongodb'
 import { Kind } from 'graphql'
 
+export const schema = `
+  scalar Cursor
+`
+
 export const resolvers = {
   ID: {
     __parseValue (value) {
@@ -12,6 +16,21 @@ export const resolvers = {
     __parseLiteral (ast) {
       if (ast.kind === Kind.STRING) {
         return ObjectId(ast.value)
+      }
+
+      return null
+    }
+  },
+  Cursor: {
+    __parseValue (value) {
+      return Buffer.from(value, 'base64').toString('ascii')
+    },
+    __serialize (value) {
+      return Buffer.from(value).toString('base64')
+    },
+    __parseLiteral (ast) {
+      if (ast.kind === Kind.STRING) {
+        return Buffer.from(ast.value, 'base64').toString('ascii')
       }
 
       return null

--- a/server/src/seed.js
+++ b/server/src/seed.js
@@ -13,63 +13,21 @@ export const seedDatabase = async ({ Facilities, Users, TypesOfWaste, Feedbacks 
         _id: new ObjectId(),
         name: 'Alumínio',
         description: 'Peças diversas feitas de alumínio',
-        icon: 'http://example.com/aluminium.png',
-        enabled: true
-      },
-      {
-        _id: new ObjectId(),
-        name: 'Compostas',
-        description: 'Compostos de lixo orgânico',
-        icon: 'http://example.com/compost.png',
-        enabled: true
-      },
-      {
-        _id: new ObjectId(),
-        name: 'Óleo de Cozinha',
-        description: 'Óleo saturado utilizado em alimentos',
-        icon: 'http://example.com/cookingOil.png',
-        enabled: true
-      },
-      {
-        _id: new ObjectId(),
-        name: 'Lixo Eletrônico',
-        description: 'Aparelhos eletrônicos diversos',
-        icon: 'http://example.com/ewaste.png',
-        enabled: true
-      },
-      {
-        _id: new ObjectId(),
-        name: 'Móveis',
-        description: 'Móveis residenciais diversos',
-        icon: 'http://example.com/furniture.png',
+        icon: 'https://s3-sa-east-1.amazonaws.com/descartae/typesOfWaste/iossmallalluminium.png',
         enabled: true
       },
       {
         _id: new ObjectId(),
         name: 'Vidro',
         description: 'Pedaços de vidro ou itens compostos de vidro',
-        icon: 'http://example.com/glass.png',
-        enabled: true
-      },
-      {
-        _id: new ObjectId(),
-        name: 'Lixo Verde',
-        description: 'Descarte de grama, folhas, galhos e semelhantes',
-        icon: 'http://example.com/greenWaste.png',
-        enabled: true
-      },
-      {
-        _id: new ObjectId(),
-        name: 'Resíduos Perigosos',
-        description: 'Itens que apresentam risco de contaminação',
-        icon: 'http://example.com/hazardousWaste.png',
+        icon: 'https://s3-sa-east-1.amazonaws.com/descartae/typesOfWaste/iossmallglass.png',
         enabled: true
       },
       {
         _id: new ObjectId(),
         name: 'Papel',
         description: 'Descarte de folhas e itens feitos inteiramente de papel',
-        icon: 'http://example.com/paper.png',
+        icon: 'https://s3-sa-east-1.amazonaws.com/descartae/typesOfWaste/iossmallpaper.png',
         enabled: true
       }
     ]
@@ -80,106 +38,411 @@ export const seedDatabase = async ({ Facilities, Users, TypesOfWaste, Feedbacks 
       email: 'user@example.com'
     }
 
-    const facilities = [
-      {
-        _id: new ObjectId(),
-        createdBy: user._id,
-        name: 'Global Plasticos',
-        location: {
-          address: 'Av. Caldeia 150',
-          municipality: 'Porto Alegre',
-          state: 'RS',
-          zip: '91130-540',
-          coordinates: {
-            latitude: -29.985346,
-            longitude: -51.1096435
-          }
-        },
-        telephone: '+55 (51) 3364-4115',
-        typesOfWaste: [
-          typesOfWaste[0]._id,
-          typesOfWaste[1]._id
-        ],
-        openHours: [
-          {
-            dayOfWeek: 'MONDAY',
-            startTime: 8,
-            endTime: 17
-          },
-          {
-            dayOfWeek: 'TUESDAY',
-            startTime: 8,
-            endTime: 17
-          },
-          {
-            dayOfWeek: 'WEDNESDAY',
-            startTime: 8,
-            endTime: 17
-          },
-          {
-            dayOfWeek: 'THURSDAY',
-            startTime: 8,
-            endTime: 17
-          },
-          {
-            dayOfWeek: 'FRIDAY',
-            startTime: 8,
-            endTime: 17
-          }
-        ],
-        enabled: true
+    const facilities = [{
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 1',
+      location: {
+        address: 'Av. Exemplo 1',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.985046,
+          longitude: -51.1099435
+        }
       },
-      {
-        _id: new ObjectId(),
-        createdBy: user._id,
-        name: 'Fkl Recargas de Cartuchos e Toners',
-        location: {
-          address: 'R. Germano Hasslocher 288 s 1',
-          municipality: 'Porto Alegre',
-          state: 'RS',
-          zip: '90160-050'
-        },
-        telephone: '+55 (51) 3232-9300',
-        typesOfWaste: [
-          typesOfWaste[1]._id
-        ],
-        openHours: [
-          {
-            dayOfWeek: 'WEDNESDAY',
-            startTime: 12,
-            endTime: 18
-          },
-          {
-            dayOfWeek: 'THURSDAY',
-            startTime: 12,
-            endTime: 18
-          },
-          {
-            dayOfWeek: 'FRIDAY',
-            startTime: 15,
-            endTime: 18
-          }
-        ],
-        enabled: true
-      }
-    ]
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id,
+        typesOfWaste[1]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 2',
+      location: {
+        address: 'Av. Exemplo 2',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.984746,
+          longitude: -51.110243499999996
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id,
+        typesOfWaste[1]._id,
+        typesOfWaste[2]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'TUESDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 3',
+      location: {
+        address: 'Av. Exemplo 3',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.984446,
+          longitude: -51.1105435
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'TUESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'WEDNESDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 4',
+      location: {
+        address: 'Av. Exemplo 4',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.984146,
+          longitude: -51.110843499999994
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id,
+        typesOfWaste[1]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'TUESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'WEDNESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'THURSDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 5',
+      location: {
+        address: 'Av. Exemplo 5',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.983846,
+          longitude: -51.1111435
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id,
+        typesOfWaste[1]._id,
+        typesOfWaste[2]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'TUESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'WEDNESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'THURSDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'FRIDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 6',
+      location: {
+        address: 'Av. Exemplo 6',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.983546,
+          longitude: -51.1114435
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'TUESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'WEDNESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'THURSDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'FRIDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'SATURDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 7',
+      location: {
+        address: 'Av. Exemplo 7',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.983246,
+          longitude: -51.111743499999996
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id,
+        typesOfWaste[1]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 8',
+      location: {
+        address: 'Av. Exemplo 8',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.982946,
+          longitude: -51.1120435
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id,
+        typesOfWaste[1]._id,
+        typesOfWaste[2]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 9',
+      location: {
+        address: 'Av. Exemplo 9',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.982646,
+          longitude: -51.112343499999994
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'TUESDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    },
+    {
+      _id: new ObjectId(),
+      createdBy: user._id,
+      name: 'Local Exemplo 10',
+      location: {
+        address: 'Av. Exemplo 10',
+        municipality: 'Porto Alegre',
+        state: 'RS',
+        zip: '91100-000',
+        coordinates: {
+          latitude: -29.982346,
+          longitude: -51.1126435
+        }
+      },
+      telephone: '+55 (51) 3000-0000',
+      typesOfWaste: [
+        typesOfWaste[0]._id,
+        typesOfWaste[1]._id
+      ],
+      openHours: [
+        {
+          dayOfWeek: 'SUNDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'MONDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'TUESDAY',
+          startTime: 12,
+          endTime: 18
+        }, {
+          dayOfWeek: 'WEDNESDAY',
+          startTime: 12,
+          endTime: 18
+        }
+      ],
+      enabled: true
+    }]
 
     const feedbacks = [
       {
         _id: new ObjectId(),
         resolved: false,
-        contents: 'Example feedback 1'
+        contents: 'Feedback Exemplo 1'
       },
       {
         _id: new ObjectId(),
         resolved: false,
         facility: facilities[0]._id,
-        contents: 'Example feedback 2'
+        contents: 'Feedback Exemplo 2'
       },
       {
         _id: new ObjectId(),
         resolved: true,
-        contents: 'Example feedback 3'
+        contents: 'Feedback Exemplo 3'
       }
     ]
 


### PR DESCRIPTION
Adds simple paging and filters to both facilities and feedbacks. For every page it is required a quantity of items to be retrieved (from 1 to 100) and the server provides both a `before` and `after` cursor, which then can be used to request the next pages. If other parameters from the query change and a cursor is provided, the only guarantee is that the items found on the first query won't be present on the new one.

Web client implementation is pending for now.

Closes #18 and closes #17. Related to #16 - depends on #33 to resolve it.